### PR TITLE
Fix UseField type definition, add micro-hooks.

### DIFF
--- a/packages/formik/src/FastField.tsx
+++ b/packages/formik/src/FastField.tsx
@@ -1,13 +1,13 @@
 import * as React from 'react';
 import { FormikValues, GenericFieldHTMLAttributes } from './types';
-import { Field, FieldConfig, FieldProps } from './Field';
+import { Field, FieldAttributes, FieldProps } from './Field';
 
 export type FastFieldProps<Value = any, FormValues = any> = FieldProps<
   Value,
   FormValues
 >;
 
-export type FastFieldConfig<V = any> = FieldConfig<V> & {
+export type FastFieldConfig<V = any> = FieldAttributes<V> & {
   /**
    * Override FastField's default shouldComponentUpdate
    * @deprecated

--- a/packages/formik/src/Field.tsx
+++ b/packages/formik/src/Field.tsx
@@ -19,36 +19,7 @@ export interface FieldProps<V = any, FormValues = any> {
   meta: FieldMetaProps<V>;
 }
 
-export interface FieldConfig<V = any> {
-  /**
-   * Field component to render. Can either be a string like 'select' or a component.
-   */
-  component?:
-    | string
-    | React.ComponentType<FieldProps<V>>
-    | React.ComponentType
-    | React.ForwardRefExoticComponent<any>;
-
-  /**
-   * Component to render. Can either be a string e.g. 'select', 'input', or 'textarea', or a component.
-   */
-  as?:
-    | React.ComponentType<FieldProps<V>['field']>
-    | string
-    | React.ComponentType
-    | React.ForwardRefExoticComponent<any>;
-
-  /**
-   * Render prop (works like React router's <Route render={props =>} />)
-   * @deprecated
-   */
-  render?: (props: FieldProps<V>) => React.ReactNode;
-
-  /**
-   * Children render function <Field name>{props => ...}</Field>)
-   */
-  children?: ((props: FieldProps<V>) => React.ReactNode) | React.ReactNode;
-
+export type UseFieldProps<V = any> = {
   /**
    * Validate a single field value independently
    */
@@ -57,12 +28,12 @@ export interface FieldConfig<V = any> {
   /**
    * Function to parse raw input value before setting it to state
    */
-  parse?: (value: unknown, name: string) => any;
+  parse?: (value: unknown, name: string) => V;
 
   /**
    * Function to transform value passed to input
    */
-  format?: (value: any, name: string) => any;
+  format?: (value: V, name: string) => any;
 
   /**
    * Wait until blur event before formatting input value?
@@ -70,6 +41,10 @@ export interface FieldConfig<V = any> {
    */
   formatOnBlur?: boolean;
 
+  /**
+   * HTML multiple attribute
+   */
+  multiple?: boolean;
   /**
    * Field name
    */
@@ -80,19 +55,10 @@ export interface FieldConfig<V = any> {
 
   /** Field value */
   value?: any;
-
-  /** Inner ref */
-  innerRef?: (instance: any) => void;
-}
-
-export type FieldAttributes<T> = GenericFieldHTMLAttributes &
-  FieldConfig<T> &
-  T & { name: string };
-
-export type FieldHookConfig<T> = GenericFieldHTMLAttributes & FieldConfig<T>;
+};
 
 export function useField<Val = any, FormValues = any>(
-  propsOrFieldName: string | FieldHookConfig<Val>
+  propsOrFieldName: string | UseFieldProps<Val>
 ): [FieldInputProps<Val>, FieldMetaProps<Val>, FieldHelperProps<Val>] {
   const formik = useFormikContext<FormValues>();
   const {
@@ -102,12 +68,9 @@ export function useField<Val = any, FormValues = any>(
     unregisterField,
   } = formik;
 
-  const isAnObject = isObject(propsOrFieldName);
-
-  // Normalize propsOrFieldName to FieldHookConfig<Val>
-  const props: FieldHookConfig<Val> = isAnObject
-    ? (propsOrFieldName as FieldHookConfig<Val>)
-    : { name: propsOrFieldName as string };
+  const props = isObject(propsOrFieldName)
+    ? propsOrFieldName
+    : { name: propsOrFieldName };
 
   const { name: fieldName, validate: validateFn } = props;
 
@@ -146,7 +109,46 @@ export function useField<Val = any, FormValues = any>(
   ];
 }
 
-export function Field<_FieldValue = any, FormValues = any>({
+export interface FieldConfig<V = any> {
+  /**
+   * Field component to render. Can either be a string like 'select' or a component.
+   */
+  component?:
+    | string
+    | React.ComponentType<FieldProps<V>>
+    | React.ComponentType
+    | React.ForwardRefExoticComponent<any>;
+
+  /**
+   * Component to render. Can either be a string e.g. 'select', 'input', or 'textarea', or a component.
+   */
+  as?:
+    | string
+    | React.ComponentType<FieldInputProps<V>>
+    | React.ComponentType
+    | React.ForwardRefExoticComponent<any>;
+
+  /**
+   * Render prop (works like React router's <Route render={props =>} />)
+   * @deprecated
+   */
+  render?: (props: FieldProps<V>) => React.ReactNode;
+
+  /**
+   * Children render function <Field name>{props => ...}</Field>)
+   */
+  children?: ((props: FieldProps<V>) => React.ReactNode) | React.ReactNode;
+
+  /** Inner ref */
+  innerRef?: (instance: any) => void;
+}
+
+export type FieldAttributes<T> = GenericFieldHTMLAttributes &
+  UseFieldProps<T> &
+  FieldConfig<T> &
+  T & { name: string };
+
+export function Field<FormValues = any>({
   render,
   children,
   as: is, // `as` is reserved in typescript lol

--- a/packages/formik/src/hooks/hooks.ts
+++ b/packages/formik/src/hooks/hooks.ts
@@ -1,9 +1,12 @@
-import { useFormikContext } from '../FormikContext';
 import { useMemo } from 'react';
+import { useFormikContext } from '../FormikContext';
 import {
   selectFieldMetaByName,
 } from '../helpers/field-helpers';
-import { FieldMetaProps, FormikState } from '../types';
+import {
+  FieldMetaProps,
+  FormikState,
+} from '../types';
 import { useFormikState } from './useFormikState';
 import { isShallowEqual } from '../utils';
 
@@ -19,8 +22,35 @@ export const useFieldMeta = <Value>(name: string): FieldMetaProps<Value> => {
   return fieldMeta;
 };
 
+const selectInitialValues = <Values>(state: FormikState<Values>) => state.initialValues;
+export const useInitialValues = <Values>() => useFormikContext<Values>().useState(selectInitialValues);
+
+const selectInitialTouched = <Values>(state: FormikState<Values>) => state.initialTouched;
+export const useInitialTouched = <Values>() => useFormikContext<Values>().useState(selectInitialTouched);
+
+const selectInitialErrors = <Values>(state: FormikState<Values>) => state.initialErrors;
+export const useInitialErrors = <Values>() => useFormikContext<Values>().useState(selectInitialErrors);
+
+const selectInitialStatus = (state: FormikState<any>) => state.initialStatus;
+export const useInitialStatus = () => useFormikContext().useState(selectInitialStatus);
+
+const selectValues = <Values>(state: FormikState<Values>) => state.values;
+export const useValues = <Values>() => useFormikContext<Values>().useState(selectValues);
+
+const selectTouched = <Values>(state: FormikState<Values>) => state.touched;
+export const useTouched = <Values>() => useFormikContext<Values>().useState(selectTouched);
+
+const selectErrors = <Values>(state: FormikState<Values>) => state.errors;
+export const useErrors = <Values>() => useFormikContext<Values>().useState(selectErrors);
+
+const selectStatus = (state: FormikState<any>) => state.status;
+export const useStatus = () => useFormikContext().useState(selectStatus);
+
 const selectIsDirty = (state: FormikState<any>) => state.dirty;
 export const useIsDirty = () => useFormikContext().useState(selectIsDirty);
 
 const selectIsValid = (state: FormikState<any>) => state.isValid;
 export const useIsValid = () => useFormikContext().useState(selectIsValid);
+
+const selectIsSubmitting = (state: FormikState<any>) => state.isSubmitting;
+export const useIsSubmitting = () => useFormikContext().useState(selectIsSubmitting);

--- a/packages/formik/src/utils.ts
+++ b/packages/formik/src/utils.ts
@@ -13,7 +13,7 @@ export const isFunction = (obj: any): obj is Function =>
   typeof obj === 'function';
 
 /** @private is the given object an Object? */
-export const isObject = (obj: any): obj is Object =>
+export const isObject = (obj: any): obj is object =>
   obj !== null && typeof obj === 'object';
 
 /** @private is the given object an integer? */
@@ -34,11 +34,11 @@ export const isEmptyChildren = (children: any): boolean =>
 
 /** @private is the given object/value a promise? */
 export const isPromise = (value: any): value is PromiseLike<any> =>
-  isObject(value) && isFunction(value.then);
+  isObject(value) && isFunction((value as any).then);
 
 /** @private is the given object/value a type of synthetic event? */
 export const isInputEvent = (value: any): value is React.SyntheticEvent<any> =>
-  value && isObject(value) && isObject(value.target);
+  value && isObject(value) && isObject((value as any).target);
 
 /** @private Are we in RN? */
 export const isReactNative =


### PR DESCRIPTION
This adds the convenience hooks from the original v3.

It doesn't add useFieldX, useSetFieldX hooks, because users should simply use `useField()`. It is not going to have a noticeable performance difference. `useField` provides the same functionality as using all the `useFieldX()` combined.